### PR TITLE
Fix d.ts types to support import types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,6 +6,44 @@ declare namespace WebpackUserscript {
     | HeaderFile // shorthand for WPUSOptions.headers
     | HeaderProvider; // shorthand for WPUSOptions.headers
 
+  interface ProxyScriptOptions {
+    /**
+     * Filename template of the proxy script.
+     * Defaults to "[basename].proxy.user.js".
+     */
+    filename?: string;
+
+    /**
+     * Base URL of the dev server.
+     * Defaults to "http://localhost:8080/".
+     */
+    baseUrl?: string;
+
+    /**
+     * Enable proxy script generation or not.
+     * Default value depends on whether `process.env.WEBPACK_DEV_SERVER` is `"true"` or not.
+     */
+    enable?: boolean | (() => boolean);
+  }
+
+  interface SsriOptions {
+    /**
+     * URL filters.
+     * Each of them is actually testing against a string compound of the meta field and the URL.
+     * For example, if a header is provided as `{ require: "http://example.com/sth.js" }`,
+     * a string of "// @require http://example.com/sth.js" is tested with the provided filters.
+     */
+    include?: string | RegExp | string[] | RegExp[];
+    exclude?: string | RegExp | string[] | RegExp[];
+
+    /**
+     * @see https://github.com/npm/ssri#--integritystreamopts---integritystream
+     */
+    algorithms?: ('sha256' | 'sha384' | 'sha512')[];
+    integrity?: string;
+    size?: number;
+  }
+
   interface WPUSOptions {
     headers?: HeaderFile | HeaderProvider | HeaderObject;
 
@@ -43,55 +81,19 @@ declare namespace WebpackUserscript {
      * Looks similar to `*.meta.js` but with additional `@require` meta field to include the main userscript.
      * It can be useful if you set TamperMonkey not to cache external files.
      */
-    proxyScript?: {
-      /**
-       * Filename template of the proxy script.
-       * Defaults to "[basename].proxy.user.js".
-       */
-      filename?: string;
-
-      /**
-       * Base URL of the dev server.
-       * Defaults to "http://localhost:8080/".
-       */
-      baseUrl?: string;
-
-      /**
-       * Enable proxy script generation or not.
-       * Default value depends on whether `process.env.WEBPACK_DEV_SERVER` is `"true"` or not.
-       */
-      enable?: boolean | (() => boolean);
-    };
+    proxyScript?: ProxyScriptOptions;
 
     /**
      * Defaults to false.
      */
-    ssri?:
-      | boolean
-      | {
-          /**
-           * URL filters.
-           * Each of them is actually testing against a string compound of the meta field and the URL.
-           * For example, if a header is provided as `{ require: "http://example.com/sth.js" }`,
-           * a string of "// @require http://example.com/sth.js" is tested with the provided filters.
-           */
-          include?: string | RegExp | string[] | RegExp[];
-          exclude?: string | RegExp | string[] | RegExp[];
-
-          /**
-           * @see https://github.com/npm/ssri#--integritystreamopts---integritystream
-           */
-          algorithms?: ('sha256' | 'sha384' | 'sha512')[];
-          integrity?: string;
-          size?: number;
-        };
+    ssri?: boolean | ssriOptions;
   }
 
   type HeaderFile = string;
 
   type HeaderProvider = (data: DataObject) => HeaderObject;
 
-  type HeaderObject = {
+  interface HeaderObject {
     name?: string;
 
     namespace?: string;
@@ -144,9 +146,9 @@ declare namespace WebpackUserscript {
     unwrap?: boolean;
 
     nocompat?: boolean | string;
-  } & {
-    [field: string]: string | string[] | boolean; // For any other field not listed above.;
-  };
+
+    [field: string]: string | string[] | boolean | undefined; // For any other field not listed above.;
+  }
 
   interface DataObject {
     /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import * as webpack from 'webpack';
 
 declare namespace WebpackUserscript {
   type WebpackUserscriptOptions =

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -86,7 +86,7 @@ declare namespace WebpackUserscript {
     /**
      * Defaults to false.
      */
-    ssri?: boolean | ssriOptions;
+    ssri?: boolean | SsriOptions;
   }
 
   type HeaderFile = string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,214 +1,213 @@
-import webpack = require("webpack");
+import webpack from 'webpack';
 
-type WebpackUserscriptOptions =
-  WPUSOptions |
-  HeaderFile |    // shorthand for WPUSOptions.headers
-  HeaderProvider  // shorthand for WPUSOptions.headers
+declare namespace WebpackUserscript {
+  type WebpackUserscriptOptions =
+    | WPUSOptions
+    | HeaderFile // shorthand for WPUSOptions.headers
+    | HeaderProvider; // shorthand for WPUSOptions.headers
 
-interface WPUSOptions {
-  headers?: HeaderFile | HeaderProvider | HeaderObject
-
-  /**
-   * Output *.meta.js files or not.
-   * Defaults to true.
-   */
-  metajs?: boolean
-
-  /**
-   * Rename all .js files to .user.js files or not.
-   * Defaults to true.
-   */
-  renameExt?: boolean
-
-  /**
-   * Prettify the header or not.
-   * Defaults to true.
-   */
-  pretty?: boolean
-
-  /**
-   * Base URL for downloadURL.
-   * If not provided, it will be set to `updateBaseUrl` if `updateBaseUrl` is provided.
-   */
-  downloadBaseUrl?: string
-
-  /**
-   * Base URL for updateURL.
-   * If not provided, it will be set to `downloadBaseUrl` if `downloadBaseUrl` is provided.
-   */
-  updateBaseUrl?: string
-
-  /**
-   * Looks similar to `*.meta.js` but with additional `@require` meta field to include the main userscript.
-   * It can be useful if you set TamperMonkey not to cache external files.
-   */
-  proxyScript?: {
-    /**
-     * Filename template of the proxy script.
-     * Defaults to "[basename].proxy.user.js".
-     */
-    filename?: string
+  interface WPUSOptions {
+    headers?: HeaderFile | HeaderProvider | HeaderObject;
 
     /**
-     * Base URL of the dev server.
-     * Defaults to "http://localhost:8080/".
+     * Output *.meta.js files or not.
+     * Defaults to true.
      */
-    baseUrl?: string
+    metajs?: boolean;
 
     /**
-     * Enable proxy script generation or not.
-     * Default value depends on whether `process.env.WEBPACK_DEV_SERVER` is `"true"` or not.
+     * Rename all .js files to .user.js files or not.
+     * Defaults to true.
      */
-    enable?: boolean | (() => boolean)
+    renameExt?: boolean;
+
+    /**
+     * Prettify the header or not.
+     * Defaults to true.
+     */
+    pretty?: boolean;
+
+    /**
+     * Base URL for downloadURL.
+     * If not provided, it will be set to `updateBaseUrl` if `updateBaseUrl` is provided.
+     */
+    downloadBaseUrl?: string;
+
+    /**
+     * Base URL for updateURL.
+     * If not provided, it will be set to `downloadBaseUrl` if `downloadBaseUrl` is provided.
+     */
+    updateBaseUrl?: string;
+
+    /**
+     * Looks similar to `*.meta.js` but with additional `@require` meta field to include the main userscript.
+     * It can be useful if you set TamperMonkey not to cache external files.
+     */
+    proxyScript?: {
+      /**
+       * Filename template of the proxy script.
+       * Defaults to "[basename].proxy.user.js".
+       */
+      filename?: string;
+
+      /**
+       * Base URL of the dev server.
+       * Defaults to "http://localhost:8080/".
+       */
+      baseUrl?: string;
+
+      /**
+       * Enable proxy script generation or not.
+       * Default value depends on whether `process.env.WEBPACK_DEV_SERVER` is `"true"` or not.
+       */
+      enable?: boolean | (() => boolean);
+    };
+
+    /**
+     * Defaults to false.
+     */
+    ssri?:
+      | boolean
+      | {
+          /**
+           * URL filters.
+           * Each of them is actually testing against a string compound of the meta field and the URL.
+           * For example, if a header is provided as `{ require: "http://example.com/sth.js" }`,
+           * a string of "// @require http://example.com/sth.js" is tested with the provided filters.
+           */
+          include?: string | RegExp | string[] | RegExp[];
+          exclude?: string | RegExp | string[] | RegExp[];
+
+          /**
+           * @see https://github.com/npm/ssri#--integritystreamopts---integritystream
+           */
+          algorithms?: ('sha256' | 'sha384' | 'sha512')[];
+          integrity?: string;
+          size?: number;
+        };
   }
 
-  /**
-   * Defaults to false.
-   */
-  ssri?: boolean | {
+  type HeaderFile = string;
+
+  type HeaderProvider = (data: DataObject) => HeaderObject;
+
+  type HeaderObject = {
+    name?: string;
+
+    namespace?: string;
+
+    version?: string;
+
+    author?: string;
+
+    description?: string;
+
+    homepage?: string;
+    homepageURL?: string;
+    website?: string;
+    source?: string;
+
+    icon?: string;
+    iconURL?: string;
+    defaulticon?: string;
+
+    icon64?: string;
+    icon64URL?: string;
+
+    updateURL?: string;
+
+    downloadURL?: string | 'none';
+    installURL?: string;
+
+    supportURL?: string;
+
+    include?: string | Array<string>;
+
+    match?: string | Array<string>;
+
+    exclude?: string | Array<string>;
+
+    require?: string | Array<string>;
+
+    resource?: string | Array<string>;
+
+    connect?: string | Array<string>;
+
+    'run-at'?: 'document-start' | 'document-body' | 'document-end' | 'document-idle' | 'context-menu';
+
+    grant?: string | Array<string> | 'none';
+
+    webRequest?: string;
+
+    noframes?: boolean;
+
+    unwrap?: boolean;
+
+    nocompat?: boolean | string;
+  } & {
+    [field: string]: string | string[] | boolean; // For any other field not listed above.;
+  };
+
+  interface DataObject {
     /**
-     * URL filters.
-     * Each of them is actually testing against a string compound of the meta field and the URL.
-     * For example, if a header is provided as `{ require: "http://example.com/sth.js" }`,
-     * a string of "// @require http://example.com/sth.js" is tested with the provided filters.
+     * Hash of Webpack compilation.
      */
-    include?: string | RegExp | string[] | RegExp[]
-    exclude?: string | RegExp | string[] | RegExp[]
+    hash: string;
 
     /**
-     * @see https://github.com/npm/ssri#--integritystreamopts---integritystream
+     * Webpack chunk hash.
      */
-    algorithms?: ("sha256" | "sha384" | "sha512")[]
-    integrity?: string
-    size?: number
+    chunkHash: string;
+
+    /**
+     * Webpack chunk name.
+     */
+    chunkName: string;
+
+    /**
+     * Entry file path, which may contain queries.
+     */
+    file: string;
+
+    /**
+     * Just like `file` but without queries.
+     */
+    filename: string;
+
+    /**
+     * Just like `filename` but without file extension, i.e. ".user.js" or ".js".
+     */
+    basename: string;
+
+    /**
+     * Query string.
+     */
+    query: string;
+
+    /**
+     * Build number.
+     */
+    buildNo: number;
+
+    /**
+     * The 13-digits number represents the time the script is built.
+     */
+    buildTime: number;
+
+    /**
+     * Info from package.json.
+     */
+    name: string;
+    version: string;
+    description: string;
+    author: string;
+    homepage: string;
+    bugs: string; // URL
   }
-}
-
-type HeaderFile = string
-
-type HeaderProvider = (data: DataObject) => HeaderObject
-
-type HeaderObject = {
-  name?: string
-
-  namespace?: string
-
-  version?: string
-
-  author?: string
-
-  description?: string
-
-  homepage?: string
-  homepageURL?: string
-  website?: string
-  source?: string
-
-  icon?: string
-  iconURL?: string
-  defaulticon?: string
-
-  icon64?: string
-  icon64URL?: string
-
-  updateURL?: string
-
-  downloadURL?: string | "none"
-  installURL?: string
-
-  supportURL?: string
-
-  include?: string | Array<string>
-
-  match?: string | Array<string>
-
-  exclude?: string | Array<string>
-
-  require?: string | Array<string>
-
-  resource?: string | Array<string>
-
-  connect?: string | Array<string>
-
-  "run-at"?:
-    "document-start" |
-    "document-body" |
-    "document-end" |
-    "document-idle" |
-    "context-menu"
-
-  grant?: string | Array<string> | "none"
-
-  webRequest?: string
-
-  noframes?: boolean
-
-  unwrap?: boolean
-
-  nocompat?: boolean | string
-  
-  [field: string]: string | string[] | boolean // For any other field not listed above.
-}
-
-interface DataObject {
-  /**
-   * Hash of Webpack compilation.
-   */
-  hash: string
-
-  /**
-   * Webpack chunk hash.
-   */
-  chunkHash: string
-
-  /**
-   * Webpack chunk name.
-   */
-  chunkName: string
-
-  /**
-   * Entry file path, which may contain queries.
-   */
-  file: string
-
-  /**
-   * Just like `file` but without queries.
-   */
-  filename: string
-
-  /**
-   * Just like `filename` but without file extension, i.e. ".user.js" or ".js".
-   */
-  basename: string
-
-  /**
-   * Query string.
-   */
-  query: string
-
-  /**
-   * Build number.
-   */
-  buildNo: number
-
-  /**
-   * The 13-digits number represents the time the script is built.
-   */
-  buildTime: number
-
-  /**
-   * Info from package.json.
-   */
-  name: string
-  version: string
-  description: string
-  author: string
-  homepage: string
-  bugs: string // URL
 }
 
 declare class WebpackUserscript {
-  constructor(options?: WebpackUserscriptOptions);
+  constructor(options?: WebpackUserscript.WebpackUserscriptOptions);
 
   apply(compiler: webpack.Compiler): void;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import * as webpack from 'webpack';
+import {Compiler, Plugin} from 'webpack';
 
 declare namespace WebpackUserscript {
   type WebpackUserscriptOptions =
@@ -206,10 +206,10 @@ declare namespace WebpackUserscript {
   }
 }
 
-declare class WebpackUserscript {
+declare class WebpackUserscript extends Plugin {
   constructor(options?: WebpackUserscript.WebpackUserscriptOptions);
 
-  apply(compiler: webpack.Compiler): void;
+  apply(compiler: Compiler): void;
 }
 
 export = WebpackUserscript;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -121,21 +121,21 @@ declare namespace WebpackUserscript {
 
     supportURL?: string;
 
-    include?: string | Array<string>;
+    include?: string | string[];
 
-    match?: string | Array<string>;
+    match?: string | string[];
 
-    exclude?: string | Array<string>;
+    exclude?: string | string[];
 
-    require?: string | Array<string>;
+    require?: string | string[];
 
-    resource?: string | Array<string>;
+    resource?: string | string[];
 
-    connect?: string | Array<string>;
+    connect?: string | string[];
 
     'run-at'?: 'document-start' | 'document-body' | 'document-end' | 'document-idle' | 'context-menu';
 
-    grant?: string | Array<string> | 'none';
+    grant?: string | string[] | 'none';
 
     webRequest?: string;
 


### PR DESCRIPTION
Redo types with namespace to support member export.

Make types file look like:
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack-dev-server/index.d.ts
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mini-css-extract-plugin/index.d.ts

to support code:
```ts
import WebpackUserscript, {HeaderOptions} from "webpack-userscript";

// currently a cannot import HeaderOptions type
const userscriptHeaders: HeaderOptions = {
    name: 'test',
};

const webpackUserscriptPlugin = new WebpackUserscript({
    headers: userscriptHeaders,
});
```

P.S.
Used prettier to auto-format source code