### PR TITLE
:lipstick: show constraint messages, not names

### DIFF
--- a/lib/features/validate-headers/impl.ts
+++ b/lib/features/validate-headers/impl.ts
@@ -52,7 +52,11 @@ export class ValidateHeaders extends Feature<ValidateHeadersOptions> {
       });
 
       if (errors.length > 0) {
-        throw new Error(errors.map((err) => err.toString()).join('\n'));
+        throw new Error(
+          errors
+            .map((err) => err.toString(undefined, undefined, undefined, true))
+            .join('\n'),
+        );
       }
     }
 


### PR DESCRIPTION
When header validation fails, the constraint message is the
human-friendly error string, show that instead of the constraint name.

Fixes #92
